### PR TITLE
Build v 0.3.0:

### DIFF
--- a/recipe/0001-point-to-correct-file-location.patch
+++ b/recipe/0001-point-to-correct-file-location.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index f46278b..4087a8e 100755
+--- a/setup.py
++++ b/setup.py
+@@ -4,7 +4,7 @@ import os
+ from setuptools import setup, find_packages
+
+
+-with open('package.json') as f:
++with open('dash_cytoscape/package.json') as f:
+     package = json.load(f)
+
+ package_name = package["name"].replace(" ", "_").replace("-", "_")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dash_cytoscape" %}
-{% set version = "0.2.0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,24 +7,34 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0669c79c197e4b150a5db7a278d1c7acebc947f3f5cbad5274835ebb44f712cd
+  sha256: a71ad4fe095570b71d4ad7c0d29199e9780c2e6796173d3b25fccc2cc58c855f
+  patches:
+    - 0001-point-to-correct-file-location.patch
 
 build:
-  noarch: python
-  number: 1
-  script: '{{ PYTHON }} -m pip install . -vv '
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - pip
-    - python >=3.5
+    - setuptools
+    - wheel
+    - python
   run:
     - dash
-    - python >=3.5
+    - python
 
 test:
+  requires:
+    - pip
   imports:
     - dash_cytoscape
+  commands:
+    - pip check
 
 about:
   home: https://github.com/plotly/dash-cytoscape
@@ -32,7 +42,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js
-  doc_url: https://dash.plot.ly/cytoscape
+  description: A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js
+  doc_url: https://dash.plotly.com/cytoscape
   dev_url: https://github.com/plotly/dash-cytoscape
 
 extra:


### PR DESCRIPTION
 Upstream: https://github.com/plotly/dash-cytoscape/tree/v0.3.0
 Jira: [PKG-2625]

 - Required by interpret*
 - Added a patch to point to the correct package.json file location in setup.py.
 - noarch removed, script command updated and deps updated as required.

[PKG-2625]: https://anaconda.atlassian.net/browse/PKG-2625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ